### PR TITLE
Hashed emails

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -11,7 +11,8 @@ exports.common = {
   },
   loginManager: {
     hash: 'sha512',
-    saltLength: 16
+    saltLength: 16,
+    saltEmail: '2571EuzCyPoQytoYvJd1aTeKnvnGXZ+T'
   }
 };
 

--- a/lib/login.js
+++ b/lib/login.js
@@ -44,7 +44,7 @@ Login.prototype.emailValidate = function(email) {
 
 Login.prototype.userLogin = function (email, password, callback) {
   var self = this;
-  db.get('user-' + encodeURIComponent(email), function (err, doc) {
+  db.get('user-' + hashEmail(email), function (err, doc) {
     if (err) {
       self.emit('error::login', err);
       return callback(err);
@@ -77,9 +77,10 @@ Login.prototype.userRegister = function (email, password, callback) {
 
   var user = {
     salt: salt,
-    hash: hash(salt, password)
+    hash: hash(salt, password),
+    email: email
   };
-  db.put('user-' + encodeURIComponent(email), user, function (err, res) {
+  db.put('user-' + hashEmail(email), user, function (err, res) {
     if (err) {
       if (err.error == 'conflict') {
         return callback({reason: 'user exists', code: Login.USER_EXISTS});
@@ -98,4 +99,10 @@ function hash(salt, password) {
   hash.update(salt + password);
   return hash.digest('hex');
 }
+exports.hash = hash;
+
+function hashEmail(email) {
+  return hash(settings.loginManager.saltEmail, email);
+}
+exports.hashEmail = hashEmail;
 

--- a/test/test-login.js
+++ b/test/test-login.js
@@ -23,20 +23,20 @@ var validEmails = [
 
 module.exports = testCase({
   setUp: function (callback) {
-    var hash = crypto.createHash(settings.loginManager.hash);
     var salt = 'salt';
     
     this.login = new login.Login();
 
     this.email = 'test@example.com';
     this.password = 'password';
-    hash.update(salt + this.password);
     this.user = {
-      hash: hash.digest('hex'),
-      salt: salt
+      hash: login.hash(salt, this.password),
+      salt: salt,
+      email: this.email
     };
     var obj = this;
-    db.save(encodeURIComponent('user-' + this.email), this.user, 
+
+    db.save('user-' + login.hashEmail(this.email), this.user,
       function (err, res) {
         if (err)
           callback(err);
@@ -81,7 +81,7 @@ module.exports = testCase({
     // TODO: test for invalid emails
     test.expect(3);
     var email = 'some-email@test.com';
-    var id = 'user-' + encodeURIComponent(email);
+    var id = 'user-' + login.hashEmail(email);
     var password = 'ninja';
     this.login.userRegister(email, password, function (err, res) {
       test.ok(!err, "shouldn't return error with valid data");


### PR DESCRIPTION
During our IRC conversation, someone pointed possibility of leaking user e-mails by using them as keys (it was @thejh probably, he's a sneaky bastard).
Now we hash those keys using the same hash function we use for passwords and some salt (salt in config is obviously just a sample one).
